### PR TITLE
Pull Request for adding full IO Mapped support

### DIFF
--- a/library_usr.mak
+++ b/library_usr.mak
@@ -31,6 +31,7 @@ MAK_SWITCH= $(SW_PREFIX)MAC_USERSPACE \
 			$(SW_PREFIX)OSS_CONFIG_PCI \
 			$(SW_PREFIX)OSS_CONFIG_VME \
 			$(SW_PREFIX)DBG \
+                        $(SW_PREFIX)OSS_USR_IO_MAPPED_ACC_EN
 
 MAK_INCL=$(MEN_INC_DIR)/men_typs.h    \
          $(MEN_INC_DIR)/../../NATIVE/MEN/vme4l.h       \

--- a/ossu_bustoaddr.c
+++ b/ossu_bustoaddr.c
@@ -41,6 +41,7 @@
 |  DEFINES & CONST                         |
 +------------------------------------------*/
 #define OSS_PAGE_SIZE 			(sysconf(_SC_PAGESIZE))
+#define IO_MAPPED_FLAG	0x01
 
 /*-----------------------------------------+
 |  GLOBALS                                 |
@@ -150,7 +151,16 @@ int32 OSS_BusToPhysAddr
 			break;
 		}
 
-		*physicalAddrP = (void *)(U_INT32_OR_64)pciDev->base_addr[addrNbr];
+		/**
+		 * pciutils lib codifies the mapping mode in the last bit, setting
+		 * it to 1 if the BAR memory is IO_MAPPED type. In such case, just
+		 * clean such bit to point to the init of the memory region.
+		*/
+		if (pciDev->base_addr[addrNbr] & IO_MAPPED_FLAG) {
+			*physicalAddrP = (void *)((U_INT32_OR_64)pciDev->base_addr[addrNbr] & ~IO_MAPPED_FLAG);
+		} else {
+			*physicalAddrP = (void *)(U_INT32_OR_64)pciDev->base_addr[addrNbr];
+		}
 		break;
 	}
 #endif /*CONFIG_PCI*/

--- a/ossu_map.c
+++ b/ossu_map.c
@@ -88,7 +88,7 @@ int32 OSS_MapPhysToVirtAddr(
 		 		 busType == OSS_BUSTYPE_PCI      ) {
 			/* for I/O no similar mapping exists under linux */
 			*virtAddrP = physAddr;
-			if( iopl(3) != 0) {
+			if( ioperm((unsigned long)physAddr, size, 1) != 0) {
 				DBGWRT_ERR((DBH,"OSS_USR - ERROR:"
 								"iopl failed, root privileges needed\n"
 								"                 IO-mapped memory access"
@@ -147,6 +147,16 @@ int32 OSS_UnMapVirtAddr(
 			unmap_size = pagesize;
 		munmap( (void*)unmap_start, unmap_size );
 	}
+#ifdef OSS_USR_IO_MAPPED_ACC_EN
+	else if( addrSpace == OSS_ADDRSPACE_IO ) {
+		if( ioperm((unsigned long)virtAddrP, size, 0) != 0) {
+					DBGWRT_1((DBH,">> OSS_USR - ERROR:"
+					"ioperm failed, root privileges needed\n"
+                    "                 IO-mapped memory access"
+                    "will not work\n"));
+		}
+	}
+#endif
 	*virtAddrP = NULL;
 	return(ERR_SUCCESS);
 }


### PR DESCRIPTION
A new specific Makefile has been created to enable IO support. Additionally, this PR fixes a bug as pciutils includes the Mapping type in last bit, so for IO mapping such bit must be set to 0. Finally, iopl has been replaced with ioperm function as iopl is deprecated.